### PR TITLE
Fix using global gemset's Rake gem

### DIFF
--- a/src/main/java/hudson/plugins/rake/Rake.java
+++ b/src/main/java/hudson/plugins/rake/Rake.java
@@ -120,15 +120,12 @@ public class Rake extends Builder {
         try {
             EnvVars env = build.getEnvironment(listener);
             if (rake != null) {
-                System.out.println("Rake GEM HOME: "+ rake.getGemHome());
                 if (rake.getGemHome() != null) {
                     env.put("GEM_HOME", rake.getGemHome());
                 }
-                System.out.println("Rake GEM PATH: "+ rake.getGemPath());
                 if (rake.getGemPath() != null) {
                     env.put("GEM_PATH", rake.getGemPath());
                 }
-                System.err.println("Rake Bin PATH: "+ rake.getBinPath());
                 if (rake.getBinPath() != null) {
                     StringBuilder builder = new StringBuilder();
                     String path = env.get("PATH");

--- a/src/main/java/hudson/plugins/rake/RvmUtil.java
+++ b/src/main/java/hudson/plugins/rake/RvmUtil.java
@@ -79,14 +79,7 @@ class RvmUtil {
                         // Add GEM bin directory to path
                         newpath = newpath.concat(File.pathSeparator).concat(new File(ruby.getGemHome(), "bin").getCanonicalPath());
 
-                        // Create or append the calculated path for this Ruby install
-                        path = ruby.getBinPath();
-                        if (path == null || path.length() == 0) {
-                            path = newpath;
-                        } else {
-                            path = path.concat(File.pathSeparator).concat(newpath);
-                        }
-                        ruby.setBinPath(path);
+                        ruby.setBinPath(newpath);
 
                         rubies.add(ruby);
                     }


### PR DESCRIPTION
I had an issue with the Rake plugin not properly detecting and setting the PATH when using gemsets that inherited the Rake gem from global.  This patch attempts to detect the Rake plugin and update the gemBinPath accordingly.
