### PR TITLE
Prepend bin path to PATH instead of appending it.

### DIFF
--- a/src/main/java/hudson/plugins/rake/Rake.java
+++ b/src/main/java/hudson/plugins/rake/Rake.java
@@ -128,12 +128,13 @@ public class Rake extends Builder {
                 }
                 if (rake.getBinPath() != null) {
                     StringBuilder builder = new StringBuilder();
+                    builder.append(rake.getBinPath());
+
                     String path = env.get("PATH");
                     if (path != null) {
-                        builder.append(path).append(File.pathSeparator);
+                        builder.append(File.pathSeparator).append(path);
                     }
 
-                    builder.append(rake.getBinPath());
                     env.put("PATH", builder.toString());
                 }
             }


### PR DESCRIPTION
If the system ruby appears in PATH before the appended bin paths, this will be used instead. This leads to unpredictable behavior (like different rake or gem versions being used). So the bin paths should be prepended to the PATH variable instead, like RVM does.

As a workaround, I currently set the PATH variable for the task with the corresponding RVM bin paths prepended, and everything works fine.
