### PR TITLE
Add option to use bundle exec

### DIFF
--- a/src/main/java/hudson/plugins/rake/RubyInstallation.java
+++ b/src/main/java/hudson/plugins/rake/RubyInstallation.java
@@ -61,6 +61,11 @@ public final class RubyInstallation {
           Util.getExecutable(getPath());
     }
 
+    public File getBundleExecutable() {
+        return getGemHome() != null ? Util.getBundleExecutable(getPath(), getGemHome(), getGemPath()) :
+          Util.getBundleExecutable(getPath());
+    }
+
     public File getCanonicalExecutable() throws IOException {
         return Util.getExecutable(getPath()).getCanonicalFile();
     }

--- a/src/main/java/hudson/plugins/rake/Util.java
+++ b/src/main/java/hudson/plugins/rake/Util.java
@@ -33,8 +33,27 @@ public class Util {
         return new File(gemHome, "bin/" + execName());
     }
 
+    public static File getBundleExecutable(String path) {
+        File parent = isJruby(path) || isCustom(path, execName())? new File(path) : new File(path).getParentFile().getParentFile();
+        return new File(parent, "bin/" + bundleExecName());
+    }
+
+    public static File getBundleExecutable(String path, String gemHome, String gemPath) {
+        for (String candidate : gemPath.split(File.pathSeparator)) {
+            File bin = new File(candidate, "bin/" + bundleExecName());
+            if (bin.exists()) {
+                return bin;
+            }
+        }
+        return new File(gemHome, "bin/" + bundleExecName());
+    }
+
     public static String execName() {
         return isWindows() ? "rake.bat" : "rake";
+    }
+
+    public static String bundleExecName() {
+        return isWindows() ? "bundle.bat" : "bundle";
     }
 
     public static boolean isWindows() {

--- a/src/main/resources/hudson/plugins/rake/Rake/config.jelly
+++ b/src/main/resources/hudson/plugins/rake/Rake/config.jelly
@@ -13,6 +13,9 @@
     <f:entry title="Tasks" description=" Specify Rake task(s) to run.">
     	<f:expandableTextbox name="rake.tasks" value="${instance.tasks}" />
   	</f:entry>
+    <f:entry title="bundle exec" description="If your project uses Bundler gem requirements manager, this option will allow you to launch rake tasks using 'bundle exec' command.">
+        <f:checkbox name="rake.bundleExec" checked="${instance.bundleExec}"/>
+    </f:entry>
   	<f:advanced>
   	    <f:entry title="Rake file" description="Specify the rake file path, by default it's './Rakefile'">
           <f:textbox name="rake.rakeFile" value="${instance.rakeFile}"/>


### PR DESCRIPTION
This PR adds a checkbox to the task to use bundle exec.  It follows all of the same ruby path lookup rules as the actual rake command and will result in a command that looks something like this:

```
/rubyhome/bin/bundle(.bat) exec rake task
```
