### PR TITLE
Add handling of absolute path for working directory

### DIFF
--- a/src/main/java/hudson/plugins/rake/Rake.java
+++ b/src/main/java/hudson/plugins/rake/Rake.java
@@ -150,7 +150,12 @@ public class Rake extends Builder {
         FilePath workingDir = build.getModuleRoot();
 
         if (rakeWorkingDir != null && rakeWorkingDir.length() > 0) {
-            workingDir = new FilePath(build.getModuleRoot(), rakeWorkingDir);
+            File file = new File(rakeWorkingDir);
+            if (file.isAbsolute()) {
+                workingDir = new FilePath(file);
+            } else {
+                workingDir = new FilePath(build.getModuleRoot(), rakeWorkingDir);
+            }
         }
 
         args.addTokenized(normalizedTasks);


### PR DESCRIPTION
This is a fix for the case where the rakefile and gemfile are not in the Jenkins workspace. An absolute path may be specified and this will not be interpreted as relative to the workspace folder.
