### PR TITLE
[JENKINS-26436] More robust search for RVM rubies.

### DIFF
--- a/src/main/java/hudson/plugins/rake/RvmUtil.java
+++ b/src/main/java/hudson/plugins/rake/RvmUtil.java
@@ -47,13 +47,13 @@ class RvmUtil {
                         String newpath = "";
                         FilePath specifications = getSpecifications(gemCandidate);
                         if (specifications != null) {
-                            Collection<FilePath> specs = specifications.list(rakeFilter);
-                            if (specs == null || specs.size() == 0) {
+                            Collection<FilePath> specs = getRakeSpecifications(specifications);
+                            if (specs.size() == 0) {
                                 // We did not find the rake gem in this gemset's bin directory; check in global
                                 specifications = getSpecifications(global);
                                 if (specifications != null) {
-                                    specs = specifications.list(rakeFilter);
-                                    if (specs == null || specs.size() == 0) {
+                                    specs = getRakeSpecifications(specifications);
+                                    if (specs.size() == 0) {
                                         // Rake not found in global either; this gemset is unusable
                                         continue;
                                     } else {
@@ -176,6 +176,18 @@ class RvmUtil {
             return rakePattern.matcher(pathname.getName()).matches();
         }
     }
+
+    private static Collection<FilePath> getRakeSpecifications(FilePath specifications)
+            throws InterruptedException, IOException {
+        Collection<FilePath> rakeSpecs = new LinkedHashSet<FilePath>();
+        rakeSpecs.addAll(specifications.list(rakeFilter));
+
+        for(FilePath subDirectory: specifications.listDirectories()) {
+            rakeSpecs.addAll(subDirectory.list(rakeFilter));
+        }
+        return rakeSpecs;
+    }
+
 
     private static FileFilter rakeFilter = new RakeSpecFilter();
 }


### PR DESCRIPTION
It appears sometimes RVM puts the rake specification in specifications/default (I'm not sure if this is a ruby 2.x change or something that rake does).

I changed the check for rake specifications to also search subdirectories of the specifications directory.  Backward compatibility is preserved but now all the ruby installations and gemsets are found, not just a subset.